### PR TITLE
Aidan/cache dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "examples"
   ],
   "scripts": {
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "prebuild": "rimraf dist",
     "build": "tsc",
     "test:start-node-server": "ts-node tests/e2e/grpc-node-server-reflection/server.ts",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "prepack": "npm run build",
+    "prepare": "npm run build",
     "prebuild": "rimraf dist",
     "build": "tsc",
     "test:start-node-server": "ts-node tests/e2e/grpc-node-server-reflection/server.ts",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "examples"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "prebuild": "rimraf dist",
     "build": "tsc",
     "test:start-node-server": "ts-node tests/e2e/grpc-node-server-reflection/server.ts",
@@ -47,7 +48,7 @@
       "ts"
     ],
     "rootDir": "tests",
-    "testRegex": "unit/.*\\.test\\.ts$",
+    "testRegex": "e2e/.*\\.test\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/src/GrpcReflection.ts
+++ b/src/GrpcReflection.ts
@@ -229,13 +229,11 @@ export class GrpcReflection {
             if (fileDescriptorProto.dependency) {
                 const dependencies = fileDescriptorProto.dependency as Array<string>;
                 for (const dep of dependencies) {
-                    console.log(`Marking ${dep} for future resolution`)
                     needsDependencyResolution.add(dep);
                 }
             }
 
             if (!fileDescriptorProtos.has(fileDescriptorProto.name as string)) {
-                console.log(`Adding ${fileDescriptorProto.name} to map`)
                 fileDescriptorProtos.set(
                     fileDescriptorProto.name as string,
                     fileDescriptorProto
@@ -246,7 +244,6 @@ export class GrpcReflection {
         // Resolve dependencies
         for (const dep of needsDependencyResolution) {
             if (fileDescriptorProtos.has(dep)) {
-                console.log(`Skipping ${dep} because it is already resolved`)
                 continue;
             }
             const depProtoBytes = await this.getProtoDescriptorByFileName(dep);

--- a/src/GrpcReflection.ts
+++ b/src/GrpcReflection.ts
@@ -245,6 +245,10 @@ export class GrpcReflection {
 
         // Resolve dependencies
         for (const dep of needsDependencyResolution) {
+            if (fileDescriptorProtos.has(dep)) {
+                console.log(`Skipping ${dep} because it is already resolved`)
+                continue;
+            }
             const depProtoBytes = await this.getProtoDescriptorByFileName(dep);
             const protoDependencies = await this.resolveDescriptorRecursive(
                 depProtoBytes as Array<Uint8Array | string>

--- a/src/GrpcReflection.ts
+++ b/src/GrpcReflection.ts
@@ -218,7 +218,7 @@ export class GrpcReflection {
         fileDescriptorProtoBytes: Array<Uint8Array | string>
     ): Promise<Map<string, IFileDescriptorProto>> {
         let fileDescriptorProtos: Map<string, IFileDescriptorProto> = new Map();
-        let needsDependencyResolution: Array<string> = [];
+        let needsDependencyResolution: Set<string> = new Set();
 
         for(const item of fileDescriptorProtoBytes){
             const fileDescriptorProto = FileDescriptorProto.decode(
@@ -230,7 +230,7 @@ export class GrpcReflection {
                 const dependencies = fileDescriptorProto.dependency as Array<string>;
                 for (const dep of dependencies) {
                     console.log(`Marking ${dep} for future resolution`)
-                    needsDependencyResolution.push(dep);
+                    needsDependencyResolution.add(dep);
                 }
             }
 


### PR DESCRIPTION
I ran into this when working with a reflection server that doesn't support `find_by_filename`, but I think it is a benefit to use cases that do as well, removing extra network traffic. TS isn't my forte, so if you think there is a cleaner way to do this then advice would be appreciated.

I tried to set up some e2e tests, but I couldn't get the node reflection server to property populate the dependencies, but it is working on my test server.